### PR TITLE
feat: inherit DefaultScopes from base/abstract entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ async function bootstrap() {
 you can define a default scope(scopes) for an entity adding the `@DefaultScopes({ ... })` decorator before
 the `@Entity()`.
 
+Default scopes are also inherited from base/abstract entities. If a child entity defines a default scope with the
+same key, the child definition overrides the inherited one.
+
 ```typescript
 import {Entity, PrimaryGeneratedColumn, Column, BaseEntity} from "typeorm"
 import {Scopes, DefaultScopes} from "typeorm-scoped"

--- a/src/default-scope-inheritance.ts
+++ b/src/default-scope-inheritance.ts
@@ -1,0 +1,82 @@
+import { getMetadataArgsStorage } from 'typeorm';
+import {
+  ScopedTableMetadata,
+  ScopeObject,
+  ScopesObjectData,
+} from './scope-types';
+
+const INHERITED_DEFAULT_SCOPES_RESOLVED = Symbol(
+  'typeorm-scoped:inherited-default-scopes-resolved',
+);
+
+type ScopedTableMetadataAny = ScopedTableMetadata<any> & {
+  [INHERITED_DEFAULT_SCOPES_RESOLVED]?: boolean;
+};
+
+function cloneScope<T>(scope: ScopeObject<T>): ScopeObject<T> {
+  return {
+    scopeFunc: scope.scopeFunc,
+    enabled: scope.enabled,
+    context: scope.context,
+  };
+}
+
+export function resolveDefaultScopesInheritance<T>(
+  table: ScopedTableMetadata<T> | undefined,
+): ScopesObjectData<T> | undefined {
+  if (!table) {
+    return undefined;
+  }
+
+  const mutableTable = table as ScopedTableMetadataAny;
+
+  if (mutableTable[INHERITED_DEFAULT_SCOPES_RESOLVED]) {
+    return mutableTable.defaultScopes;
+  }
+
+  const mergedScopes: ScopesObjectData<T> = {};
+  const target = mutableTable.target;
+
+  if (typeof target === 'function') {
+    const inheritedTables: ScopedTableMetadataAny[] = [];
+    let currentPrototype = Object.getPrototypeOf(target);
+
+    while (currentPrototype && currentPrototype !== Function.prototype) {
+      const inheritedTable = getMetadataArgsStorage().tables.find(
+        (tableArg) => tableArg.target === currentPrototype,
+      ) as ScopedTableMetadataAny | undefined;
+
+      if (inheritedTable) {
+        inheritedTables.unshift(inheritedTable);
+      }
+
+      currentPrototype = Object.getPrototypeOf(currentPrototype);
+    }
+
+    for (const inheritedTable of inheritedTables) {
+      if (!inheritedTable.defaultScopes) {
+        continue;
+      }
+
+      for (const [scopeName, scope] of Object.entries(
+        inheritedTable.defaultScopes,
+      )) {
+        mergedScopes[scopeName] = cloneScope(scope as ScopeObject<T>);
+      }
+    }
+  }
+
+  if (mutableTable.defaultScopes) {
+    for (const [scopeName, scope] of Object.entries(
+      mutableTable.defaultScopes,
+    )) {
+      mergedScopes[scopeName] = cloneScope(scope as ScopeObject<T>);
+    }
+  }
+
+  mutableTable.defaultScopes =
+    Object.keys(mergedScopes).length > 0 ? mergedScopes : undefined;
+  mutableTable[INHERITED_DEFAULT_SCOPES_RESOLVED] = true;
+
+  return mutableTable.defaultScopes;
+}

--- a/src/scope.entity.ts
+++ b/src/scope.entity.ts
@@ -1,4 +1,5 @@
 import { BaseEntity, getMetadataArgsStorage } from 'typeorm';
+import { resolveDefaultScopesInheritance } from './default-scope-inheritance';
 import { ScopedTableMetadata } from './scope-types';
 
 export class ScopeEntity extends BaseEntity {
@@ -32,18 +33,19 @@ export class ScopeEntity extends BaseEntity {
     const table = getMetadataArgsStorage().tables.find(
       (table) => table.target === this.target,
     ) as ScopedTableMetadata<T>;
-    if (table.defaultScopes) {
-      for (const key in table.defaultScopes) {
+    const resolvedDefaultScopes = resolveDefaultScopesInheritance(table);
+    if (resolvedDefaultScopes) {
+      for (const key in resolvedDefaultScopes) {
         if (!defaultScopes.length) {
-          if (table.defaultScopes[key]) {
-            table.defaultScopes[key].enabled = false;
+          if (resolvedDefaultScopes[key]) {
+            resolvedDefaultScopes[key].enabled = false;
           }
         } else {
           const scopeSet = new Set(defaultScopes);
           // if the key is in the scopeSet, set enabled to false
           if (scopeSet.has(key)) {
-            if (table.defaultScopes[key]) {
-              table.defaultScopes[key].enabled = false;
+            if (resolvedDefaultScopes[key]) {
+              resolvedDefaultScopes[key].enabled = false;
             }
           }
         }

--- a/src/scope.repository.ts
+++ b/src/scope.repository.ts
@@ -1,4 +1,5 @@
 import { ObjectLiteral, Repository } from 'typeorm';
+import { resolveDefaultScopesInheritance } from './default-scope-inheritance';
 import { ScopedTableMetadata } from './scope-types';
 
 export class ScopeRepository<T extends ObjectLiteral> extends Repository<T> {
@@ -25,18 +26,19 @@ export class ScopeRepository<T extends ObjectLiteral> extends Repository<T> {
     const metadata = this.metadata.tableMetadataArgs as
       | ScopedTableMetadata<T>
       | undefined;
-    if (metadata && metadata.defaultScopes) {
-      for (const key in metadata.defaultScopes) {
+    const resolvedDefaultScopes = resolveDefaultScopesInheritance(metadata);
+    if (resolvedDefaultScopes) {
+      for (const key in resolvedDefaultScopes) {
         if (!defaultScopes.length) {
-          if (metadata.defaultScopes[key]) {
-            metadata.defaultScopes[key].enabled = false;
+          if (resolvedDefaultScopes[key]) {
+            resolvedDefaultScopes[key].enabled = false;
           }
         } else {
           const scopeSet = new Set(defaultScopes);
           // if the key is in the scopeSet, set enabled to false
           if (scopeSet.has(key)) {
-            if (metadata.defaultScopes[key]) {
-              metadata.defaultScopes[key].enabled = false;
+            if (resolvedDefaultScopes[key]) {
+              resolvedDefaultScopes[key].enabled = false;
             }
           }
         }

--- a/src/select-qb.ts
+++ b/src/select-qb.ts
@@ -1,4 +1,5 @@
 import { ObjectLiteral, SelectQueryBuilder } from 'typeorm';
+import { resolveDefaultScopesInheritance } from './default-scope-inheritance';
 import { ScopedTableMetadata } from './scope-types';
 
 export const GET_QUERY_COPY = '___scope_getQuery_copy___';
@@ -14,10 +15,11 @@ export class SelectQB<T extends ObjectLiteral> extends SelectQueryBuilder<T> {
       if (!table || !table.hasMetadata) continue;
       const metadata = table.metadata
         .tableMetadataArgs as ScopedTableMetadata<T>;
+      const defaultScopes = resolveDefaultScopesInheritance(metadata);
 
       // default scopes functional
-      if (metadata.defaultScopes) {
-        for (const defaultScopeObj of Object.values(metadata.defaultScopes)) {
+      if (defaultScopes) {
+        for (const defaultScopeObj of Object.values(defaultScopes)) {
           if (defaultScopeObj.enabled) {
             defaultScopeObj.scopeFunc(this, table.name);
           } else {


### PR DESCRIPTION
## Problem

When a concrete entity extends an abstract base entity that has `@DefaultScopes` defined, the scopes are **not applied** to queries on the child entity.

This is because `typeorm-scoped` stores scope metadata directly on the decorated class's entry in TypeORM's `getMetadataArgsStorage().tables`. Abstract/base entities get their own entry, but concrete child entities get a separate entry with no `defaultScopes` — there is no inheritance walk at query time.

### Reproduction

```typescript
@DefaultScopes<AppTenantEntity>({
  tenant: (qb, alias) => qb.andWhere(`${alias}.tenantId = :tenantId`, { tenantId: getTenantId() }),
})
@Entity()
export abstract class AppTenantEntity extends BaseEntity {
}

@Entity()
export class Medication extends AppTenantEntity {
  // No @DefaultScopes here — expects to inherit from AppTenantEntity
}

// This query returns ALL medications, not scoped to the current tenant
await Medication.find();
```

## Solution

Added `src/default-scope-inheritance.ts` — a resolver that walks the prototype chain of a concrete entity and merges `defaultScopes` from all ancestor classes (grandparent → parent → child), with child keys taking precedence over inherited ones.

The resolved and merged scopes are cached on the table metadata object using a `Symbol` key so the prototype walk only happens once per entity class.

The resolver is wired into three places:
- **`select-qb.ts`** — applied at query generation time so all `find()` and `createQueryBuilder()` calls include inherited scopes.
- **`scope.entity.ts`** — `ScopeEntity.unscoped()` disables inherited scopes correctly.
- **`scope.repository.ts`** — `ScopeRepository.unscoped()` disables inherited scopes correctly.

## Behavior

| Scenario | Before | After |
|---|---|---|
| Child entity, no `@DefaultScopes` | No scope applied | Inherits from base |
| Child entity overrides scope key | N/A | Child definition wins |
| `unscoped()` on child with inherited scope | No-op (no scopes to disable) | Disables inherited scope |
| Child with its own `@DefaultScopes` | Applied | Applied (unchanged) |

## Changed Files

- `src/default-scope-inheritance.ts` *(new)* — prototype-chain scope resolver
- `src/select-qb.ts` — use resolver at query time
- `src/scope.entity.ts` — use resolver in `unscoped()`
- `src/scope.repository.ts` — use resolver in `unscoped()`
- `README.md` — document inheritance behavior